### PR TITLE
docs: use pnpm run plugins install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ imports.
 From the Etherpad working directory, run:
 
 ```shell
-npm install --no-save --legacy-peer-deps ep_disable_imports
+pnpm run plugins install ep_disable_imports
 ```
 
 Or, install from Etherpad's `/admin/plugins` page.


### PR DESCRIPTION
## Summary
Etherpad uses pnpm internally. The canonical install command per [etherpad-lite/doc/plugins.md](https://github.com/ether/etherpad-lite/blob/develop/doc/plugins.md) is `pnpm run plugins install ep_<name>`, not `npm install`. Update README to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)