### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_disable_imports/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_disable_imports/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_disable_imports/actions/workflows/test-and-release.yml)
 
-# ep_disable_imports
+# Disable Imports in Etherpad
 
 [Etherpad](https://etherpad.org/) plugin to selectively or completely disable
 imports.


### PR DESCRIPTION
Replace the placeholder `ep_disable_imports` heading in README.md with "Disable Imports in Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.