### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const assert = require('assert').strict;
-const log4js = require('ep_etherpad-lite/node_modules/log4js');
+const {createLogger} = require('ep_plugin_helpers/logger');
 
-const logger = log4js.getLogger('ep_disable_imports');
+const logger = createLogger('ep_disable_imports');
 let allow = new Set();
 let deny = new Set();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_disable_imports",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "Etherpad plugin to selectively or completely disable imports.",
   "main": "index.js",
   "scripts": {
@@ -33,5 +33,8 @@
   "funding": {
     "type": "individual",
     "url": "https://etherpad.org/"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.6.7"
   }
 }


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Migrate log4js from `require("ep_etherpad-lite/node_modules/log4js")` to `ep_plugin_helpers/logger`

This change is **backward-compatible** with the current CJS etherpad release.